### PR TITLE
update Dockerfile, add entrypoint script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,11 @@ EOF
 
 # Setup Greyhole for Samba
 ADD --link --keep-git-dir=false https://github.com/gboudreau/Greyhole.git /Greyhole-master
+
+WORKDIR /Greyhole-master
 RUN <<EOF 
     set -xe
-    cd /Greyhole-master
+
     # Greyhole
 	mkdir -p /var/spool/greyhole
 	chmod 777 /var/spool/greyhole
@@ -30,6 +32,7 @@ RUN <<EOF
     install -m 0755 -D -p greyhole.cron.weekly /etc/cron.weekly/greyhole
     install -m 0755 -D -p greyhole.cron.daily /etc/cron.daily/greyhole
     install -m 0755 -D -p build_vfs.sh /usr/share/greyhole/build_vfs.sh
+    
 	# WebUI
     install -m 0644 -D -p web-app/index.php /usr/share/greyhole/web-app/index.php
     install -m 0644 -D -p web-app/README /usr/share/greyhole/web-app/README
@@ -56,6 +59,8 @@ RUN <<EOF
     install -m 0644 -D -p web-app/views/status.php /usr/share/greyhole/web-app/views/status.php
     install -m 0644 -D -p web-app/views/storage_pool.php /usr/share/greyhole/web-app/views/storage_pool.php
     install -m 0644 -D -p web-app/views/trash.php /usr/share/greyhole/web-app/views/trash.php
+    
+    # Finalise install
     mkdir -p /var/cache/greyhole-dfree
     chmod 777 /var/cache/greyhole-dfree
     mv includes /usr/share/greyhole/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,15 @@
 
 FROM alpine:3.15
 
+ARG PHP_VERSION=php8
+
 RUN <<EOF
     set -x
     apk --no-cache add \
     samba-common-tools samba-client samba-server \
     bash ncurses curl python3 gcc libc-dev perl make rpcgen file ssmtp supervisor gnutls-dev zlib-dev rsyslog \
-    php8-cli php8-pdo_mysql php8-intl php8-mbstring php8-intl php8-mysqlnd php8-json php8-pcntl rsync lsof sysstat findutils gzip patch
-    ln -s /usr/bin/php8 /usr/bin/php
+    $PHP_VERSION-cli $PHP_VERSION-pdo_mysql $PHP_VERSION-intl $PHP_VERSION-mbstring $PHP_VERSION-intl $PHP_VERSION-mysqlnd $PHP_VERSION-json $PHP_VERSION-pcntl rsync lsof sysstat findutils gzip patch
+    ln -s /usr/bin/$PHP_VERSION /usr/bin/php
 EOF
 
 # Setup Greyhole for Samba
@@ -16,6 +18,7 @@ ADD --link --keep-git-dir=false https://github.com/gboudreau/Greyhole.git /Greyh
 RUN <<EOF 
     set -xe
     cd /Greyhole-master
+    # Greyhole
 	mkdir -p /var/spool/greyhole
 	chmod 777 /var/spool/greyhole
 	mkdir -p /usr/share/greyhole
@@ -62,13 +65,13 @@ RUN <<EOF
     ln -s /usr/share/greyhole/greyhole-dfree /usr/bin/greyhole-dfree
     ln -s /usr/share/greyhole/greyhole-php /usr/bin/greyhole-php
     ln -s /usr/share/greyhole/greyhole /usr/bin/cpgh
-	echo "include_path=.:/usr/share/php8:/usr/share/greyhole" > /etc/php8/conf.d/02_greyhole.ini
+	echo "include_path=.:/usr/share/$PHP_VERSION:/usr/share/greyhole" > /etc/$PHP_VERSION/conf.d/02_greyhole.ini
 EOF
 
 # Re-use pre-compiled .so or build a new one
 WORKDIR /usr/share/greyhole/
 #COPY alpine-samba-patches/*.patch ./
-COPY --chmod=755 --link install_greyhole_vfs.sh .
+COPY --chmod=755 --link install_greyhole_vfs.sh ./
 RUN bash ./install_greyhole_vfs.sh
 
 # Copy additional scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,79 +1,83 @@
+# syntax = docker/dockerfile-upstream:master-labs
+
 FROM alpine:3.15
 
-RUN apk --no-cache add \
+RUN <<EOF
+    set -x
+    apk --no-cache add \
     samba-common-tools samba-client samba-server \
     bash ncurses curl python3 gcc libc-dev perl make rpcgen file ssmtp supervisor gnutls-dev zlib-dev rsyslog \
-    php8-cli php8-pdo_mysql php8-intl php8-mbstring php8-intl php8-mysqlnd php8-json php8-pcntl rsync lsof sysstat findutils gzip patch \
-    && ln -s /usr/bin/php8 /usr/bin/php
-
-# SSMTP (to be able to send emails)
-COPY ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "hostname=$(hostname).home.danslereseau.com" >> /etc/ssmtp/ssmtp.conf
+    php8-cli php8-pdo_mysql php8-intl php8-mbstring php8-intl php8-mysqlnd php8-json php8-pcntl rsync lsof sysstat findutils gzip patch
+    ln -s /usr/bin/php8 /usr/bin/php
+EOF
 
 # Setup Greyhole for Samba
-ARG GREYHOLE_VERSION=master
-ADD "https://api.github.com/repos/gboudreau/Greyhole/commits?per_page=1" /tmp/latest_commit
-RUN curl -Lo greyhole-master.zip https://github.com/gboudreau/Greyhole/archive/$GREYHOLE_VERSION.zip && \
-    unzip greyhole-master.zip >/dev/null && \
-    rm greyhole-master.zip && \
-    cd Greyhole-* && \
-	mkdir -p /var/spool/greyhole && \
-	chmod 777 /var/spool/greyhole && \
-	mkdir -p /usr/share/greyhole && \
-	install -m 0755 -D -p greyhole /usr/share/greyhole && \
-	install -m 0755 -D -p greyhole-dfree /usr/share/greyhole && \
-    install -m 0755 -D -p greyhole-php /usr/share/greyhole && \
-    install -m 0755 -D -p greyhole-dfree.php /usr/share/greyhole && \
-    install -m 0644 -D -p greyhole.cron.d /etc/cron.d/greyhole && \
-    install -m 0755 -D -p greyhole.cron.weekly /etc/cron.weekly/greyhole && \
-    install -m 0755 -D -p greyhole.cron.daily /etc/cron.daily/greyhole && \
-    install -m 0755 -D -p build_vfs.sh /usr/share/greyhole/build_vfs.sh && \
+ADD --link --keep-git-dir=false https://github.com/gboudreau/Greyhole.git /Greyhole-master
+RUN <<EOF 
+    set -xe
+    cd /Greyhole-master
+	mkdir -p /var/spool/greyhole
+	chmod 777 /var/spool/greyhole
+	mkdir -p /usr/share/greyhole
+	install -m 0755 -D -p greyhole /usr/share/greyhole
+	install -m 0755 -D -p greyhole-dfree /usr/share/greyhole
+    install -m 0755 -D -p greyhole-php /usr/share/greyhole
+    install -m 0755 -D -p greyhole-dfree.php /usr/share/greyhole
+    install -m 0644 -D -p greyhole.cron.d /etc/cron.d/greyhole
+    install -m 0755 -D -p greyhole.cron.weekly /etc/cron.weekly/greyhole
+    install -m 0755 -D -p greyhole.cron.daily /etc/cron.daily/greyhole
+    install -m 0755 -D -p build_vfs.sh /usr/share/greyhole/build_vfs.sh
 	# WebUI
-    install -m 0644 -D -p web-app/index.php /usr/share/greyhole/web-app/index.php && \
-    install -m 0644 -D -p web-app/README /usr/share/greyhole/web-app/README && \
-    install -m 0644 -D -p web-app/LICENSE.md /usr/share/greyhole/web-app/LICENSE.md && \
-    install -m 0644 -D -p web-app/favicon.png /usr/share/greyhole/web-app/favicon.png && \
-    install -m 0644 -D -p web-app/includes.inc.php /usr/share/greyhole/web-app/includes.inc.php && \
-    install -m 0644 -D -p web-app/init.inc.php /usr/share/greyhole/web-app/init.inc.php && \
-    install -m 0644 -D -p web-app/config_definitions.inc.php /usr/share/greyhole/web-app/config_definitions.inc.php && \
-    install -m 0644 -D -p web-app/scripts.js /usr/share/greyhole/web-app/scripts.js && \
-    install -m 0644 -D -p web-app/styles.css /usr/share/greyhole/web-app/styles.css && \
-    install -m 0644 -D -p web-app/du/index.php /usr/share/greyhole/web-app/du/index.php && \
-    install -m 0644 -D -p web-app/install/index.php /usr/share/greyhole/web-app/install/index.php && \
-    install -m 0644 -D -p web-app/install/step1.inc.php /usr/share/greyhole/web-app/install/step1.inc.php && \
-    install -m 0644 -D -p web-app/install/step2.inc.php /usr/share/greyhole/web-app/install/step2.inc.php && \
-    install -m 0644 -D -p web-app/install/step3.inc.php /usr/share/greyhole/web-app/install/step3.inc.php && \
-    install -m 0644 -D -p web-app/install/step4.inc.php /usr/share/greyhole/web-app/install/step4.inc.php && \
-    install -m 0644 -D -p web-app/install/step5.inc.php /usr/share/greyhole/web-app/install/step5.inc.php && \
-    install -m 0644 -D -p web-app/install/step6.inc.php /usr/share/greyhole/web-app/install/step6.inc.php && \
-    install -m 0644 -D -p web-app/install/step7.inc.php /usr/share/greyhole/web-app/install/step7.inc.php && \
-    install -m 0644 -D -p web-app/views/actions.php /usr/share/greyhole/web-app/views/actions.php && \
-    install -m 0644 -D -p web-app/views/greyhole_config.php /usr/share/greyhole/web-app/views/greyhole_config.php && \
-    install -m 0644 -D -p web-app/views/samba_config.php /usr/share/greyhole/web-app/views/samba_config.php && \
-    install -m 0644 -D -p web-app/views/samba_shares.php /usr/share/greyhole/web-app/views/samba_shares.php && \
-    install -m 0644 -D -p web-app/views/status.php /usr/share/greyhole/web-app/views/status.php && \
-    install -m 0644 -D -p web-app/views/storage_pool.php /usr/share/greyhole/web-app/views/storage_pool.php && \
-    install -m 0644 -D -p web-app/views/trash.php /usr/share/greyhole/web-app/views/trash.php && \
-    mkdir -p /var/cache/greyhole-dfree && chmod 777 /var/cache/greyhole-dfree && \
-    mv includes /usr/share/greyhole/ && \
-    mv samba-module /usr/share/greyhole/ && \
-    ln -s /config-greyhole/greyhole.conf /etc/greyhole.conf && \
-    ln -s /usr/share/greyhole/greyhole /usr/bin/greyhole && \
-    ln -s /usr/share/greyhole/greyhole-dfree /usr/bin/greyhole-dfree && \
-    ln -s /usr/share/greyhole/greyhole-php /usr/bin/greyhole-php && \
-    ln -s /usr/share/greyhole/greyhole /usr/bin/cpgh && \
+    install -m 0644 -D -p web-app/index.php /usr/share/greyhole/web-app/index.php
+    install -m 0644 -D -p web-app/README /usr/share/greyhole/web-app/README
+    install -m 0644 -D -p web-app/LICENSE.md /usr/share/greyhole/web-app/LICENSE.md
+    install -m 0644 -D -p web-app/favicon.png /usr/share/greyhole/web-app/favicon.png
+    install -m 0644 -D -p web-app/includes.inc.php /usr/share/greyhole/web-app/includes.inc.php
+    install -m 0644 -D -p web-app/init.inc.php /usr/share/greyhole/web-app/init.inc.php
+    install -m 0644 -D -p web-app/config_definitions.inc.php /usr/share/greyhole/web-app/config_definitions.inc.php
+    install -m 0644 -D -p web-app/scripts.js /usr/share/greyhole/web-app/scripts.js
+    install -m 0644 -D -p web-app/styles.css /usr/share/greyhole/web-app/styles.css
+    install -m 0644 -D -p web-app/du/index.php /usr/share/greyhole/web-app/du/index.php
+    install -m 0644 -D -p web-app/install/index.php /usr/share/greyhole/web-app/install/index.php
+    install -m 0644 -D -p web-app/install/step1.inc.php /usr/share/greyhole/web-app/install/step1.inc.php
+    install -m 0644 -D -p web-app/install/step2.inc.php /usr/share/greyhole/web-app/install/step2.inc.php
+    install -m 0644 -D -p web-app/install/step3.inc.php /usr/share/greyhole/web-app/install/step3.inc.php
+    install -m 0644 -D -p web-app/install/step4.inc.php /usr/share/greyhole/web-app/install/step4.inc.php
+    install -m 0644 -D -p web-app/install/step5.inc.php /usr/share/greyhole/web-app/install/step5.inc.php
+    install -m 0644 -D -p web-app/install/step6.inc.php /usr/share/greyhole/web-app/install/step6.inc.php
+    install -m 0644 -D -p web-app/install/step7.inc.php /usr/share/greyhole/web-app/install/step7.inc.php
+    install -m 0644 -D -p web-app/views/actions.php /usr/share/greyhole/web-app/views/actions.php
+    install -m 0644 -D -p web-app/views/greyhole_config.php /usr/share/greyhole/web-app/views/greyhole_config.php
+    install -m 0644 -D -p web-app/views/samba_config.php /usr/share/greyhole/web-app/views/samba_config.php
+    install -m 0644 -D -p web-app/views/samba_shares.php /usr/share/greyhole/web-app/views/samba_shares.php
+    install -m 0644 -D -p web-app/views/status.php /usr/share/greyhole/web-app/views/status.php
+    install -m 0644 -D -p web-app/views/storage_pool.php /usr/share/greyhole/web-app/views/storage_pool.php
+    install -m 0644 -D -p web-app/views/trash.php /usr/share/greyhole/web-app/views/trash.php
+    mkdir -p /var/cache/greyhole-dfree
+    chmod 777 /var/cache/greyhole-dfree
+    mv includes /usr/share/greyhole/
+    mv samba-module /usr/share/greyhole/
+    ln -s /config-greyhole/greyhole.conf /etc/greyhole.conf
+    ln -s /usr/share/greyhole/greyhole /usr/bin/greyhole
+    ln -s /usr/share/greyhole/greyhole-dfree /usr/bin/greyhole-dfree
+    ln -s /usr/share/greyhole/greyhole-php /usr/bin/greyhole-php
+    ln -s /usr/share/greyhole/greyhole /usr/bin/cpgh
 	echo "include_path=.:/usr/share/php8:/usr/share/greyhole" > /etc/php8/conf.d/02_greyhole.ini
+EOF
 
 # Re-use pre-compiled .so or build a new one
 WORKDIR /usr/share/greyhole/
 #COPY alpine-samba-patches/*.patch ./
-COPY install_greyhole_vfs.sh .
+COPY --chmod=755 --link install_greyhole_vfs.sh .
 RUN bash ./install_greyhole_vfs.sh
 
-COPY start_greyhole_daemon.sh /start_greyhole_daemon.sh
-
+# Copy additional scripts
+COPY --link --chmod=755 entrypoint.sh /entrypoint.sh
+COPY --chmod=755 --link start_greyhole_daemon.sh /start_greyhole_daemon.sh
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 VOLUME ["/var/cache/samba", "/var/lib/samba", "/var/log/samba", "/run/samba", "/config-greyhole", "/usr/share/greyhole"]
+
+ENTRYPOINT ["/entrypoint.sh"]
 
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,12 @@
 
 FROM alpine:3.15
 
+# Add whichever Greyhole version you want. 'master' for the master branch, or versioned, e.g. GREYHOLE_VERSION=0.15.18
+ARG GREYHOLE_VERSION=master
 ARG PHP_VERSION=php8
 
 RUN <<EOF
-    set -x
+    set -xe
     apk --no-cache add \
     samba-common-tools samba-client samba-server \
     bash ncurses curl python3 gcc libc-dev perl make rpcgen file ssmtp supervisor gnutls-dev zlib-dev rsyslog \
@@ -14,7 +16,7 @@ RUN <<EOF
 EOF
 
 # Setup Greyhole for Samba
-ADD --link --keep-git-dir=false https://github.com/gboudreau/Greyhole.git /Greyhole-master
+ADD --link --keep-git-dir=false https://github.com/gboudreau/Greyhole.git#$GREYHOLE_VERSION /Greyhole-master
 
 WORKDIR /Greyhole-master
 RUN <<EOF 
@@ -77,7 +79,12 @@ EOF
 WORKDIR /usr/share/greyhole/
 #COPY alpine-samba-patches/*.patch ./
 COPY --chmod=755 --link install_greyhole_vfs.sh ./
-RUN bash ./install_greyhole_vfs.sh
+
+
+RUN <<EOF 
+    set -xe
+    bash ./install_greyhole_vfs.sh
+EOF
 
 # Copy additional scripts
 COPY --link --chmod=755 entrypoint.sh /entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euo pipefail
+
+MAILHOST="${MAILHOST:-"$(hostname)"}"
+MAILDOMAIN="${MAILDOMAIN:-"home.danslereseau.com"}"
+MAILROOT="${MAILROOT:-"postmaster"}"
+MAILHUB="${MAILHUB:-"172.17.0.1:25"}"
+MAILHOSTNAME="${MAILHOSTNAME:-"$MAILHOST.$MAILDOMAIN"}"
+
+# Create ssmpt.conf
+tee /etc/ssmtp/ssmtp.conf << EOF >/dev/null
+# The user that gets all the mails (UID < 1000, usually the admin)
+root=$MAILROOT
+# The mail server (where the mail is sent to), both port 465 or 587 should be acceptable
+mailhub=$MAILHUB
+# Email 'From header's can override the default domain?
+FromLineOverride=YES
+# The full hostname.  Must be correctly formed, fully qualified domain name or GMail will reject connection.
+hostname=$MAILHOSTNAME
+EOF
+
+exec "$@"


### PR DESCRIPTION
@gboudreau - Given how much I use Greyhole, I thought I'd give something back other than the donation:

- Updated & optimised Dockerfile to use Buildkit and Heredoc.
- Created entrypoint script to make it possible and easier to create env vars. 
- Have added the git repo via docker ADD rather than requiring curl, rm etc etc etc, just makes it cleaner and quicker, with fewer steps. You can also lock this to a particular release.*
- Have added an ARG for PHP version, as this'll make it quicker to change later down the line (and can easily test new PHP versions).

---

*Example of locking git download to a particular version:
```Dockerfile
ARG GREYHOLE_VERSION=0.15.18
ADD --link --keep-git-dir=false https://github.com/gboudreau/Greyhole.git#$GREYHOLE_VERSION /Greyhole-master
```

---

New env vars for SSMPT:
| Variable | Default |
| :----: | --- |
| MAILHOST | $(hostname) |
| MAILDOMAIN | home.danslereseau.com |
| MAILROOT | postmaster |
| MAILHUB | 172.17.0.1:25 |
| MAILHOSTNAME | $(hostname).home.danslereseau.com |

This removes the requirement to add and append the ssmpt.conf file during the image build, and allows for easier user customisation later down the line, rather than being hardcoded (also doesn't invalidate the full build cache if you need to change it).

The entrypoint script also allows for further customisability for Greyhole if you wish.

---

The command I'm using to build is:
`DOCKER_BUILDKIT=1 docker build --build-arg BUILDKIT_INLINE_CACHE=1 -t greyhole:test -f Dockerfile .`